### PR TITLE
Add Django settings and enable django-distill static export

### DIFF
--- a/DivUnion/asgi.py
+++ b/DivUnion/asgi.py
@@ -1,0 +1,11 @@
+"""ASGI config for DivUnion."""
+
+from __future__ import annotations
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "DivUnion.settings")
+
+application = get_asgi_application()

--- a/DivUnion/settings.py
+++ b/DivUnion/settings.py
@@ -1,0 +1,144 @@
+"""Django settings for the DivUnion project.
+
+The configuration is intentionally compact but production ready enough for
+local development and the Netlify static export build used by this
+repository.  Values that should be customised in production can be
+provided via environment variables.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import List
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Security -----------------------------------------------------------------
+SECRET_KEY = os.environ.get(
+    "DJANGO_SECRET_KEY",
+    "django-insecure-9@x6$0y4r@7vqumr8vmt=*#)w=b^=f8@9a2t-#=3w)y=z!m6m!",
+)
+DEBUG = os.environ.get("DJANGO_DEBUG", "0") == "1"
+
+raw_allowed_hosts = os.environ.get("DJANGO_ALLOWED_HOSTS", "")
+if raw_allowed_hosts:
+    ALLOWED_HOSTS: List[str] = [host.strip() for host in raw_allowed_hosts.split(",") if host.strip()]
+else:
+    ALLOWED_HOSTS = ["*"]
+
+CSRF_TRUSTED_ORIGINS = [
+    origin.strip()
+    for origin in os.environ.get("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
+    if origin.strip()
+]
+
+# Applications --------------------------------------------------------------
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "crispy_forms",
+    "crispy_bootstrap5",
+    "django_filters",
+    "django_distill",
+    "accounts",
+    "store",
+]
+
+CRISPY_ALLOWED_TEMPLATE_PACKS = ["bootstrap5"]
+CRISPY_TEMPLATE_PACK = "bootstrap5"
+
+AUTH_USER_MODEL = "accounts.CustomUser"
+
+# Middleware ----------------------------------------------------------------
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "DivUnion.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "DivUnion.wsgi.application"
+ASGI_APPLICATION = "DivUnion.asgi.application"
+
+# Database ------------------------------------------------------------------
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+# Password validation -------------------------------------------------------
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
+
+# Internationalisation ------------------------------------------------------
+LANGUAGE_CODE = "en-gb"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+# Static & media ------------------------------------------------------------
+STATIC_URL = "static/"
+STATICFILES_DIRS = [BASE_DIR / "static"]
+STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+MEDIA_URL = "media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+DISTILL_DIR = BASE_DIR / "distill_build"
+
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "index"
+LOGOUT_REDIRECT_URL = "index"
+
+SESSION_COOKIE_AGE = 60 * 60 * 24 * 30  # 30 days
+SESSION_COOKIE_HTTPONLY = True
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+EMAIL_BACKEND = os.environ.get(
+    "DJANGO_EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+)
+
+COOKIE_CONSENT_NAME = "cookie_consent"

--- a/DivUnion/urls.py
+++ b/DivUnion/urls.py
@@ -1,0 +1,41 @@
+"""URL configuration for the DivUnion project."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterator, Optional
+
+from django.contrib import admin
+from django.urls import include, path
+from django_distill import distill_path
+
+from . import views
+
+
+def distill_none() -> Iterator[Optional[Dict[str, str]]]:
+    """Helper that yields a single ``None`` value for static export."""
+
+    yield None
+
+
+def distill_products() -> Iterator[Dict[str, str]]:
+    """Yield keyword arguments for each product detail page."""
+
+    yield from views.iter_distill_products()
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    distill_path("", views.index, name="index", distill_func=distill_none),
+    distill_path("ai/", views.ai_agent, name="ai", distill_func=distill_none),
+    distill_path("contact/", views.contact, name="contact", distill_func=distill_none),
+    distill_path("shop/", views.shop_redirect, name="shop", distill_func=distill_none),
+    distill_path(
+        "product/<slug:slug>/",
+        views.product_detail_static,
+        name="product_detail",
+        distill_func=distill_products,
+    ),
+    path("dashboard/", views.dashboard_home, name="dashboard_home"),
+    path("accounts/", include("accounts.urls")),
+    path("store/", include(("store.urls", "store"), namespace="store")),
+]

--- a/DivUnion/views.py
+++ b/DivUnion/views.py
@@ -1,0 +1,106 @@
+"""Core views for the DivUnion project."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple, Dict
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.db import OperationalError
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+
+from store.models import Product
+from store import views as store_views
+
+Conversation = List[Tuple[str, str]]
+
+
+def _get_products(limit: int | None = None) -> Iterable[Product]:
+    """Return a list of products, swallowing database errors during builds."""
+
+    try:
+        queryset = Product.objects.all()
+        if limit is not None:
+            queryset = queryset[:limit]
+        return list(queryset)
+    except OperationalError:
+        return []
+
+
+def index(request: HttpRequest) -> HttpResponse:
+    """Homepage showing featured products."""
+
+    products = _get_products(limit=6)
+    return render(request, "index.html", {"products": products})
+
+
+def _generate_response(message: str) -> str:
+    """Return a canned AI response based on simple keyword matching."""
+
+    lowered = message.lower()
+    if "shipping" in lowered:
+        return "We ship worldwide. Orders are dispatched within two business days."
+    if "support" in lowered or "help" in lowered:
+        return "Our support team is available 24/7 via support@divunion.com."
+    if "refund" in lowered or "return" in lowered:
+        return "You can request a return within 30 days of delivery for a full refund."
+    if "price" in lowered or "cost" in lowered:
+        return "All prices shown include taxes; shipping is calculated at checkout."
+    return "Thanks for your message! A specialist will follow up shortly."
+
+
+def ai_agent(request: HttpRequest) -> HttpResponse:
+    """Toy AI support chatbot that keeps a short conversation in session storage."""
+
+    conversation: Conversation = request.session.get("ai_conversation", [])
+    if request.method == "POST":
+        user_message = request.POST.get("message", "").strip()
+        if user_message:
+            conversation.append(("You", user_message))
+            conversation.append(("DivUnion AI", _generate_response(user_message)))
+            request.session["ai_conversation"] = conversation
+            request.session.modified = True
+    return render(request, "ai.html", {"conversation": conversation})
+
+
+def contact(request: HttpRequest) -> HttpResponse:
+    """Contact form that acknowledges receipt without sending email."""
+
+    if request.method == "POST":
+        messages.success(request, "Thanks! We'll be in touch soon.")
+        return redirect("contact")
+    return render(request, "contact.html")
+
+
+@login_required
+def dashboard_home(request: HttpRequest) -> HttpResponse:
+    """Simple dashboard restricted to developer accounts."""
+
+    if not getattr(request.user, "is_developer", False):
+        raise PermissionDenied("Developer access required")
+    stats = {"product_count": len(_get_products())}
+    return render(request, "dashboard/home.html", {"stats": stats})
+
+
+def shop_redirect(request: HttpRequest) -> HttpResponse:
+    """Proxy to the store catalogue view while keeping the legacy URL name."""
+
+    return store_views.shop(request)
+
+
+def product_detail_static(request: HttpRequest, slug: str) -> HttpResponse:
+    """Proxy product detail view used for top-level URLs and static export."""
+
+    return store_views.product_detail(request, slug=slug)
+
+
+def iter_distill_products() -> Iterable[Dict[str, str]]:
+    """Yield mapping objects for each product when building static files."""
+
+    try:
+        for slug in Product.objects.values_list("slug", flat=True):
+            yield {"slug": slug}
+    except OperationalError:
+        return

--- a/DivUnion/wsgi.py
+++ b/DivUnion/wsgi.py
@@ -1,0 +1,11 @@
+"""WSGI config for DivUnion."""
+
+from __future__ import annotations
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "DivUnion.settings")
+
+application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-distill==3.2.4
 django-crispy-forms==2.3
 crispy-bootstrap5==2025.6
 django-filter==24.2
+Pillow==10.4.0

--- a/store/urls.py
+++ b/store/urls.py
@@ -1,12 +1,12 @@
-"""
-URL configuration for the store app.
+"""URL configuration for the store app."""
 
-Includes paths for viewing the product catalogue and individual product
-detail pages.
-"""
+from __future__ import annotations
+
 from django.urls import path
+
 from . import views
 
+app_name = "store"
 
 urlpatterns = [
     path("", views.shop, name="shop"),

--- a/store/views.py
+++ b/store/views.py
@@ -4,15 +4,24 @@ Views for the store app.
 Provide pages for browsing products, filtering by name and category and
 viewing individual product details.
 """
-from django.shortcuts import render, get_object_or_404
-from .models import Product
+from django.db import OperationalError
+from django.shortcuts import get_object_or_404, render
+
 from .filters import ProductFilter
+from .models import Product
 
 
 def shop(request):
     """Display the product catalogue with filtering options."""
-    product_filter = ProductFilter(request.GET or None, queryset=Product.objects.all())
-    products = product_filter.qs
+    try:
+        queryset = Product.objects.all()
+    except OperationalError:
+        queryset = Product.objects.none()
+    product_filter = ProductFilter(request.GET or None, queryset=queryset)
+    try:
+        products = product_filter.qs
+    except OperationalError:
+        products = Product.objects.none()
     return render(request, "store/shop.html", {
         "filter": product_filter,
         "products": products,

--- a/templates/dashboard/home.html
+++ b/templates/dashboard/home.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block title %}Developer Dashboard{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h1 class="mb-4">Developer Dashboard</h1>
+    <p class="lead">Welcome back, {{ request.user.username }}.</p>
+    <div class="row g-4">
+        <div class="col-md-4">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h2 class="display-5">{{ stats.product_count }}</h2>
+                    <p class="text-muted">Products in catalogue</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title">What's next?</h3>
+                    <p class="card-text mb-0">Use this space to track development tasks and roadmap ideas.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add the missing DivUnion project configuration with django_distill in INSTALLED_APPS so Netlify can run the static export
- expose top-level URLs and helper views that proxy to the store app for distill and add a simple developer dashboard template
- declare the Pillow dependency and harden catalogue views for empty databases used during static builds

## Testing
- python manage.py distill-local --force *(fails locally: Pillow wheel cannot be downloaded in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0af8e0734832ca761c0a250925c59